### PR TITLE
コマンドラインオプションで grep オプションが指定された場合の処理を追加

### DIFF
--- a/Finder.java
+++ b/Finder.java
@@ -32,6 +32,9 @@ public class Finder {
 	if(args.getSize() != null){
             flag &= checkTargetSize(file, args.getSize());
         }
+	if(args.getGrep() != null){
+            flag &= checkGrep(file, args.getGrep());
+        }
 
         return flag;
     }
@@ -70,6 +73,20 @@ public class Finder {
                 return file.length() == size;
             default:
                 // ignore
+            }
+        }
+        return false;
+    }
+
+    private boolean checkGrep(File file, String pattern){
+        if(file.isFile()){
+            try(BufferedReader in = new BufferedReader(new FileReader(file))){
+                String line;
+                while((line = in.readLine()) != null){
+                    if(line.indexOf(pattern) >= 0){
+                        return true;
+                    }
+                }
             }
         }
         return false;


### PR DESCRIPTION
・grepオプションは，ファイルの中身を検索し，指定された文字列が含まれたファイルであれば結果に含めるものとする．

・ファイルはテキストファイルであると決め打ちで読むこととする．

・検査対象がディレクトリの場合は，常に false を返す．
